### PR TITLE
Fixed exception on Argument.TryParseToValue

### DIFF
--- a/Common/RoslynEditor.cs
+++ b/Common/RoslynEditor.cs
@@ -1,4 +1,4 @@
-﻿namespace SSkyline.DataMiner.CICD.CSharpAnalysis
+﻿namespace Skyline.DataMiner.CICD.CSharpAnalysis
 {
     using System;
     using System.Collections.Generic;

--- a/Common/RoslynHelper.cs
+++ b/Common/RoslynHelper.cs
@@ -17,8 +17,6 @@
     using Skyline.DataMiner.CICD.CSharpAnalysis.Classes;
     using Skyline.DataMiner.CICD.CSharpAnalysis.Enums;
 
-    using SSkyline.DataMiner.CICD.CSharpAnalysis;
-
     /// <summary>
     /// Roslyn helper class.
     /// </summary>
@@ -458,7 +456,6 @@
             return false;
         }
 
-
         /// <summary>
         /// Tries parsing the specified expression as a value.
         /// </summary>
@@ -850,7 +847,7 @@
                     {
                         Type = Value.ValueType.Unknown,
                         HasNotChanged = true,
-                        Object = GetFullyQualifiedName(semanticModel, oces),
+                        Object = oces.ToFullString(),
                     };
                     succeeded = true;
                     break;


### PR DESCRIPTION
GetFullyQualifiedName() doesn't work with ObjectCreationExpressionSyntax when it's part of another project.
As it was just to fill something in the 'Object' of the Value, I've changed it to ToFullString() instead.

Added extra test cases to test other projects.
Changed the SolutionBuilderHelper to be able to create a solution with 2 projects.